### PR TITLE
Test to enable simple links between containers and child records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.DS_Store

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
     - ak-solrlogs:/opt/solr/server/logs
     - ak-solrdata:/opt/solr/server/solr
     - ak-harvest:/opt/harvest
-    - /Users/mamo/ACDH-CH/VuFind/AkSearchSolr/local/import:/opt/local/import
-    - /Users/mamo/ACDH-CH/VuFind/AkSearchSolr/sample:/tmp/sample
+    - ../AkSearchSolr/local/import:/opt/local/import
+    - ../AkSearchSolr/sample:/tmp/sample
     ports:
     - "8983:8983"
     networks:
@@ -34,7 +34,7 @@ services:
     - "80:80"
     volumes:
     - ak-harvest:/var/www/local/harvest/alma
-    - /Users/mamo/ACDH-CH/VuFind/AkSearchWeb/local:/var/www/local
+    - ./local:/var/www/local
     networks:
     - backend
     - bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,10 @@ services:
     - ak-solrlogs:/opt/solr/server/logs
     - ak-solrdata:/opt/solr/server/solr
     - ak-harvest:/opt/harvest
+    - /Users/mamo/ACDH-CH/VuFind/AkSearchSolr/local/import:/opt/local/import
+    - /Users/mamo/ACDH-CH/VuFind/AkSearchSolr/sample:/tmp/sample
+    ports:
+    - "8983:8983"
     networks:
     - backend
   ak-mysql:
@@ -25,11 +29,12 @@ services:
     - SOLR_URL=http://ak-solr:8983/solr
     - ALMA_KEY=xxx
     - VUFIND_LOCAL_MODULES=AkSearch,AkSearchApi,AkSearchConsole,AkSearchSearch,aksearchExt
-    - APPLICATION_ENV=testing
+    - APPLICATION_ENV=development
     ports:
     - "80:80"
     volumes:
     - ak-harvest:/var/www/local/harvest/alma
+    - /Users/mamo/ACDH-CH/VuFind/AkSearchWeb/local:/var/www/local
     networks:
     - backend
     - bridge
@@ -44,4 +49,3 @@ volumes:
   ak-solrdata:
   ak-mysql:
   ak-harvest:
-   

--- a/local/config/vufind/Alma.ini
+++ b/local/config/vufind/Alma.ini
@@ -2,7 +2,7 @@
 ; The base URL for your Alma instance (example is public demo):
 apiBaseUrl = "https://api-eu.hosted.exlibrisgroup.com/almaws/v1"
 ; An API key configured to allow access to Alma:
-apiKey = ""
+apiKey = xxx
 ; Timeout in seconds when making HTTP requests to the Alma APIs:
 http_timeout = 30
 ; Patron login method to use. The following options are available:

--- a/local/config/vufind/RecordTabs.ini
+++ b/local/config/vufind/RecordTabs.ini
@@ -1,0 +1,154 @@
+; This file controls the display of tabs on the Record page for various types of
+; records. Each section name matches a record driver class name, and those settings
+; will be used when displaying that type of record. If no settings are found for a
+; particular class, its parent classes will be checked in turn; thus, you could set
+; up global defaults using a [VuFind\RecordDriver\AbstractBase] section.
+;
+; Within each section, the following settings are supported:
+;
+; tabs[X] = Y -- This activates a tab, using "X" to identify that tab in the URL,
+;                and using a service named "Y" loaded from the RecordTab plugin
+;                manager. The order of tabs entries controls display order.
+; defaultTab  -- This matches an "X" value from a tabs setting, and controls which
+;                tab is active by default. If empty, the global default tab setting
+;                (defaultRecordTab) from config.ini will be used.
+; backgroundLoadedTabs[] -- This repeatable setting can be used to identify tabs
+;                that should be asynchronously loaded in the background to improve
+;                performance. Use the "X" value from the tabs setting as the id.
+[VuFind\RecordDriver\EDS]
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[Details] = StaffViewArray
+defaultTab = null
+
+[VuFind\RecordDriver\Pazpar2]
+tabs[Details] = StaffViewMARC
+defaultTab = null
+
+[VuFind\RecordDriver\Primo]
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[Details] = StaffViewArray
+defaultTab = null
+
+[VuFind\RecordDriver\SolrAuthDefault]
+tabs[Details] = StaffViewArray
+defaultTab = null
+
+[VuFind\RecordDriver\SolrAuthMarc]
+tabs[Details] = StaffViewMARC
+defaultTab = null
+
+[VuFind\RecordDriver\DefaultRecord]
+tabs[Holdings] = HoldingsILS
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+; Commented out by default because only useful when simpleContainerLinks = true
+; in config.ini:
+tabs[ComponentParts] = ComponentParts
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[HierarchyTree] = HierarchyTree
+;tabs[CollectionList] = CollectionList
+;tabs[CollectionHierarchyTree] = CollectionHierarchyTree
+tabs[Map] = Map
+tabs[Versions] = Versions
+tabs[Similar] = SimilarItemsCarousel
+tabs[Details] = StaffViewArray
+defaultTab = null
+;backgroundLoadedTabs[] = UserComments
+;backgroundLoadedTabs[] = Details
+
+[VuFind\RecordDriver\Search2Default]
+tabs[Holdings] = HoldingsILS
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+; Commented out by default because only useful when simpleContainerLinks = true
+; in config.ini:
+tabs[ComponentParts] = ComponentParts
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[HierarchyTree] = HierarchyTree
+;tabs[Search2CollectionList] = Search2CollectionList
+;tabs[CollectionHierarchyTree] = CollectionHierarchyTree
+tabs[Map] = Map
+tabs[Versions] = Versions
+tabs[Similar] = SimilarItemsCarousel
+tabs[Details] = StaffViewArray
+defaultTab = null
+;backgroundLoadedTabs[] = UserComments
+;backgroundLoadedTabs[] = Details
+
+[VuFind\RecordDriver\SolrMarc]
+tabs[Holdings] = HoldingsILS
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+; Commented out by default because only useful when simpleContainerLinks = true
+; in config.ini:
+tabs[ComponentParts] = ComponentParts
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[HierarchyTree] = HierarchyTree
+tabs[Map] = Map
+tabs[Versions] = Versions
+tabs[Similar] = SimilarItemsCarousel
+tabs[Details] = StaffViewMARC
+defaultTab = null
+
+[VuFind\RecordDriver\SolrOverdrive]
+tabs[Description] = Description
+tabs[Formats] = Formats
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[HierarchyTree] = HierarchyTree
+tabs[Map] = Map
+tabs[Versions] = Versions
+tabs[Similar] = SimilarItemsCarousel
+tabs[Details] = StaffViewOverdrive
+defaultTab = null
+
+[VuFind\RecordDriver\Summon]
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Preview] = preview
+tabs[Details] = StaffViewArray
+defaultTab = null
+
+[VuFind\RecordDriver\WorldCat]
+tabs[Holdings] = HoldingsWorldCat
+tabs[Description] = Description
+tabs[TOC] = TOC
+tabs[UserComments] = UserComments
+tabs[Reviews] = Reviews
+tabs[Excerpt] = Excerpt
+tabs[Details] = StaffViewMARC
+defaultTab = null
+
+; TabScripts is a special section that defines any extra scripts that may be required
+; by a tab. Settings are named by the tab name (X above) and may be repeated if
+; multiple scripts are required.
+[TabScripts]
+Versions[] = openurl.js
+Versions[] = combined-search.js
+Versions[] = check_item_statuses.js
+Versions[] = record_versions.js

--- a/local/config/vufind/config.ini
+++ b/local/config/vufind/config.ini
@@ -11,7 +11,7 @@ available       = true
 ; Change to true to see messages about the behavior of the system as part of the
 ; output -- only for use when troubleshooting problems. See also the access.DebugMode
 ; setting in permissions.ini to turn on debug using a GET parameter in the request.
-debug           = false
+debug           = true
 ; This setting should be set to false after auto-configuration is complete
 autoConfigure = true
 ; This setting specifies a health check file location. If a health check file exists,

--- a/local/config/vufind/config.ini
+++ b/local/config/vufind/config.ini
@@ -1736,7 +1736,7 @@ treeSearchLimit = 100
 ; (see the [Collections] section), so only one of them should be enabled
 ; at a time e.g. unless custom record drivers are used. When using this setting,
 ; you may also wish to enable the ComponentParts tab in RecordTabs.ini.
-;simpleContainerLinks = true
+simpleContainerLinks = true
 
 ; This section will be used to configure the feedback module.
 ; Set "tab_enabled" to true in order to enable the feedback module.

--- a/local/config/vufind/config.ini
+++ b/local/config/vufind/config.ini
@@ -246,7 +246,7 @@ session_name = VUFIND_SESSION
 ; Note: Enabling most of the features in this section will only work if you use an
 ; ILS driver that supports them; not all drivers support holds/renewals.
 [Catalog]
-driver          = Alma
+driver          = NoILS
 
 ; loadNoILSOnFailure - Whether or not to load the NoILS driver if the main driver fails
 loadNoILSOnFailure = false
@@ -520,7 +520,7 @@ ils_encryption_key = false
 ; url can also be an array of servers. If so, VuFind will try the servers one by one
 ; until one can be reached. This is only useful for advanced fault-tolerant Solr
 ; installations.
-url             = http://oeaw_resources_solr:8983/solr
+url = http://ak-solr:8983/solr
 ; Default bibliographic record core
 default_core    = biblio
 ; Default authority record core
@@ -612,7 +612,7 @@ url_shortener = none
 ; [host] = host of database server
 ; [port] = port of database server (optional)
 ; [db] = database name
-database          = willBeFilledAutomaticallyByTheDeploymentScripts
+database = mysql://vufind:zxcasd@ak-mysql/vufind
 
 ; If your database (e.g. PostgreSQL) uses a schema, you can set it here:
 ;schema = schema_name


### PR DESCRIPTION
I have tried to enable containers to display some sort of hierarchy between the resources. Links are based on the AC-control numbers (= local field MARC 009 in our catalogue). The link is established between the Solr fields `is_hierarchy_id` (in the **parent** resource) and `hierarchy_parent_id` (in the **child** resource). Containers were enabled in the `config.ini` file and componentParts in the `RecordTabs.ini` file.
It's still very tentative and buggy:

- I still can't display the link to the parent resource in the child resource (links are displayed just one way, from parent to child).
- I mapped the field `container_title` (which apparently is required to display links to containers) to `245a`, which might not be the right solution, but was a temporary escamotage to make it work
- **And most importantly**: If you click on the link to display child resources, you won't find any, because Solr queries to find child resources are built by searching the MMS ID (and not the AC-control number) in the `hierarchy_parent_id` field.

👉 A related branch, with the same name, is available in the repo for AkSearchSolr, where the **mapping** is to be found.